### PR TITLE
Speed up string replace

### DIFF
--- a/src/esy/buildEjectCommand/index.js
+++ b/src/esy/buildEjectCommand/index.js
@@ -381,21 +381,6 @@ function buildEjectCommand(
   });
 
   emitFile({
-    filename: ['bin/replace-string'],
-    executable: true,
-    contents: outdent`
-      #!/usr/bin/env bash
-
-      FILENAME="$1"
-      SRC="$2"
-      DST="$3"
-
-      # In-place rename, with literal strings -- no regex
-      perl -pi -e "s/\\\Q\${SRC}/\${DST}/g" "\${FILENAME}"
-    `
-  });
-
-  emitFile({
     filename: ['bin', 'runtime.sh'],
     contents: RUNTIME
   });

--- a/src/esy/buildEjectCommand/index.js
+++ b/src/esy/buildEjectCommand/index.js
@@ -384,26 +384,14 @@ function buildEjectCommand(
     filename: ['bin/replace-string'],
     executable: true,
     contents: outdent`
-      #!/usr/bin/env python2
+      #!/usr/bin/env bash
 
-      import sys
-      import os
-      import stat
+      FILENAME="$1"
+      SRC="$2"
+      DST="$3"
 
-      filename, src, dest = sys.argv[1:4]
-      filename_stage = filename + '.esy_rewrite'
-
-      filestat = os.stat(filename)
-
-      # TODO: we probably should handle symlinks too in a special way,
-      # to modify their location to a rewritten path
-
-      with open(filename, 'r') as input_file, open(filename_stage, 'w') as output_file:
-        for line in input_file:
-            output_file.write(line.replace(src, dest))
-
-      os.rename(filename_stage, filename)
-      os.chmod(filename, stat.S_IMODE(filestat.st_mode))
+      # In-place rename, with literal strings -- no regex
+      perl -pi -e "s/\\\Q\${SRC}/\${DST}/g" "\${FILENAME}"
     `
   });
 

--- a/src/esy/buildEjectCommand/index.js
+++ b/src/esy/buildEjectCommand/index.js
@@ -398,13 +398,9 @@ function buildEjectCommand(
       # TODO: we probably should handle symlinks too in a special way,
       # to modify their location to a rewritten path
 
-      with open(filename, 'r') as input_file:
-        data = input_file.read()
-
-      data = data.replace(src, dest)
-
-      with open(filename_stage, 'w') as output_file:
-        output_file.write(data)
+      with open(filename, 'r') as input_file, open(filename_stage, 'w') as output_file:
+        for line in input_file:
+            output_file.write(line.replace(src, dest))
 
       os.rename(filename_stage, filename)
       os.chmod(filename, stat.S_IMODE(filestat.st_mode))

--- a/src/esy/buildEjectCommand/runtime.sh
+++ b/src/esy/buildEjectCommand/runtime.sh
@@ -45,6 +45,15 @@ _esy-prepare-build-env () {
 
 }
 
+replace-string () {
+  FILENAME="$1"
+  SRC="$2"
+  DST="$3"
+
+  # In-place rename, with literal strings -- no regex
+  perl -pi -e "s/\Q${SRC}/${DST}/g" "${FILENAME}"
+}
+
 _esy-perform-build () {
 
   _esy-prepare-build-env
@@ -73,21 +82,12 @@ _esy-perform-build () {
     exit 1
   else
     for filename in `find $cur__install -type f`; do
-      $ESY__ROOT/bin/replace-string "$filename" "$cur__install" "$esy_build__install"
+      replace-string "$filename" "$cur__install" "$esy_build__install"
     done
     mv $cur__install $esy_build__install
     echo -e "${FG_GREEN}*** $cur__name: build complete${FG_RESET}"
   fi
 
-}
-
-replace-string () {
-  FILENAME="$1"
-  SRC="$2"
-  DST="$3"
-
-  # In-place rename, with literal strings -- no regex
-  perl -pi -e "s/\\\Q\${SRC}/\${DST}/g" "\${FILENAME}"
 }
 
 esy-build () {

--- a/src/esy/buildEjectCommand/runtime.sh
+++ b/src/esy/buildEjectCommand/runtime.sh
@@ -81,6 +81,15 @@ _esy-perform-build () {
 
 }
 
+replace-string () {
+  FILENAME="$1"
+  SRC="$2"
+  DST="$3"
+
+  # In-place rename, with literal strings -- no regex
+  perl -pi -e "s/\\\Q\${SRC}/\${DST}/g" "\${FILENAME}"
+}
+
 esy-build () {
   if [ "$esy_build__source_type" == "local" ]; then
     esy-clean


### PR DESCRIPTION
Use Perl instead of Python.

**Summary**

Current replace loads Python. Could use a Perl one liner instead.

**Test plan**

Should be a drop-in replacement with existing tests.