### PR TITLE
Esy better escaping [DO NOT MERGE YET]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /lib
 /lib-legacy
+/bin/EsyYarnCache-*
 /node_modules
 *.log
 /.nyc_output

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ Support for "ejecting" a build is computed and stored in
 ###### Package Cache
 
 `esy` currently uses Yarn to perform the installs, but ensures that it uses its
-own isolated cache.  You can see where this cache is by running:
+own isolated package cache. (note: this is different than `esy`'s build cache).
+You can see where this cache is by running:
 
 ```
 dirname $(realpath `which esy`)

--- a/bin/esy
+++ b/bin/esy
@@ -3,6 +3,9 @@
 ESY__VERSION="3.0.0"
 # The store is compatible with any major version 3.
 ESY__STORE_VERSION="3.x.x"
+# The caches are compatible with any major version 3.
+ESY__CACHE_VERSION="3.x.x"
+
 # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -11,6 +14,11 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   [[ $SOURCE != /* ]] && SOURCE="$SCRIPTDIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+# We store the yarn cache in the binary directory (not the node symlink farm
+# directory, but the real directory where esy lives) so that when you uninstall
+# esy, and then reinstall it, you will intentionally bust the cache.
+ESY__YARN_CACHE_DIR="$SCRIPTDIR/EsyYarnCache-$ESY__CACHE_VERSION/"
 
 # Had to remove this so that we could just use one command `esy` which we
 # forward everything to.
@@ -103,7 +111,7 @@ builtIn() {
 }
 
 builtInYarn() {
-	node $SCRIPTDIR/yarn.js $@
+	node $SCRIPTDIR/yarn.js $@ --cache-folder $ESY__YARN_CACHE_DIR
 }
 
 if [ "$1" == "build" ] || [ "$1" == "build-shell" ] || [ "$1" == "clean" ]; then

--- a/bin/esy
+++ b/bin/esy
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+ESY__VERSION="3.0.0"
+# The store is compatible with any major version 3.
+ESY__STORE_VERSION="3.x.x"
 # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -30,7 +33,7 @@ if [ -z "${ESY__SANDBOX+x}" ]; then
   export ESY__SANDBOX="$PWD"
 fi
 if [ -z "${ESY__STORE+x}" ]; then
-  export ESY__STORE="$HOME/.esy/store"
+  export ESY__STORE="$HOME/.esy/store-$ESY__STORE_VERSION"
 fi
 if [ -z "${ESY__LOCAL_STORE+x}" ]; then
   export ESY__LOCAL_STORE="$ESY__SANDBOX/node_modules/.cache/_esy/store"

--- a/opam-packages-conversion/bin/config.py
+++ b/opam-packages-conversion/bin/config.py
@@ -1,5 +1,7 @@
 import os.path
 
+from lib import normalize_package_name_to_var_name
+
 __dir__ = os.path.dirname(os.path.realpath(__file__))
 
 os.environ['PATH'] = '%s:%s' % (__dir__, os.environ['PATH'])
@@ -61,11 +63,11 @@ def export_caml_ld_library_path(name, stublibs=False):
     }
 
 def caml_ld_library_path(name, stublibs=False):
-    norm_name = name.replace('-', '_')
+    norm_name = normalize_package_name_to_var_name ('opam-alpha/' + name)
     # Note that opam_alpha comes from opam-alpha prefix that we use.
     return {
         'scope': 'global',
-        'val': '$opam_alpha_%s__lib/%s:$CAML_LD_LIBRARY_PATH' % (
+        'val': '$%s__lib/%s:$CAML_LD_LIBRARY_PATH' % (
             norm_name,
             'stublibs' if stublibs else name),
     }

--- a/opam-packages-conversion/convertedPackages.txt
+++ b/opam-packages-conversion/convertedPackages.txt
@@ -1,6 +1,6 @@
 # Forks
 ./forks/camlp4 esy/4.02+7 4.02+7
-./forks/ocamlfind esy/1.7.1 origin/master
+./forks/ocamlfind origin/esy/1.7.1 origin/master
 
 # Direct convertation
 base-threads base

--- a/src/esy/Sandbox.js
+++ b/src/esy/Sandbox.js
@@ -414,11 +414,33 @@ function objectToDependencySpecList(...objs) {
   return dependencySpecList;
 }
 
+/**
+ * See https://github.com/reasonml/esy/issues/3
+ *
+ * This scheme:
+ *  - does not use - (hyphen) for normalized names.
+ *  - does not use __ for normalized names (double under is reserved for our
+ *    own suffixes in esy).
+ *
+ *
+ * Details:
+ *
+ *   .                    __dot__
+ *   /                    __slash__
+ *    - (hyphen)          _ (under)
+ *    _ (under)           ___ (triple under)
+ *    __ (double under)   ____ (quadruple)
+ */
 function normalizeName(name) {
   return name
     .toLowerCase()
     .replace(/@/g, '')
-    .replace(/\//g, '_')
+    .replace(/_+/g, (matched, arg2, arg3) => {
+      return matched + '__';
+    })
+    .replace(/\//g, '__slash__')
+    // Add two underscores to every group we see.
+    .replace(/\./g, '__dot__')
     .replace(/\-/g, '_');
 }
 

--- a/src/esy/buildEjectCommand/index.js
+++ b/src/esy/buildEjectCommand/index.js
@@ -259,8 +259,6 @@ function buildEjectCommand(
 
       let allDependencies = collectTransitiveDependencies(packageInfo);
 
-      let packageEnv = `${packageJson.name}__env`;
-
       emitPackageFile({
         filename: 'env',
         contents: renderEnv(buildEnvironment),


### PR DESCRIPTION
The only reason why this can't be merged is because when releasing this, the yarn cache still gets the old version of the ocamlfind package.json (which I've had to fix as part of this diff).

Is there any automatic solution to that problem? If not now, it will come up eventually.

    This requires bumping the esy version - and I've also created a
    convention of encoding the esy version in the store.

    Really, we want two different versions - the esy version, and then the
    store compatibility version. Bumping major esy versions needn't
    necessarily bump the store encoding version, but for simplicity sake,
    let's consider them the same version.

    Test Plan:
