### PR TITLE
[ESY] Do Not Add Env Vars For non Esy Packages.

### DIFF
--- a/src/esy/PackageEnvironment.js
+++ b/src/esy/PackageEnvironment.js
@@ -288,6 +288,11 @@ function computeEnvVarsForPackage(
   packageInfo: PackageInfo
 ) {
   let {rootDirectory, packageJson, normalizedName} = packageInfo;
+  // Do not compute package environment for this one package, if it
+  // does not have an `esy` field.
+  if (packageJson.esy && packageJson.esy.__noEsyConfigPresent) {
+    return;
+  }
   var packageJsonDir = path.dirname(rootDirectory);
   var packageName = packageJson.name;
   var envVarConfigPrefix = normalizedName;

--- a/src/esy/Sandbox.js
+++ b/src/esy/Sandbox.js
@@ -382,6 +382,7 @@ async function readPackageJson(filename): Promise<PackageJson> {
       build: null,
       exportedEnv: {},
       buildsInSource: false,
+      __noEsyConfigPresent: true
     };
   }
   if (packageJson.esy.build == null) {


### PR DESCRIPTION
Summary:This avoids adding env vars when you include a non-compiled package
(static resources or JS dependency etc).

Test Plan:

Reviewers:

CC:

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
