### PR TITLE
Fixing esy's github repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ When developing `esy` (or cloning the repo to use locally), you must have `filte
 
 To make changes to `esy` and test them locally, check out and build the `esy` repo as such:
 
-    git clone git@github.com:jordwalke/esy.git
+    git clone git://github.com/reasonml/esy.git
     cd esy
     npm install
     git submodule init


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The github repo's URL used in the README.md file is an old one and is defunct.
I updated it to the one currently being used.

**Test plan**
I tried cloning the repo from the old URL and it didn't work, while doing the same from the new one worked fine.
