### PR TITLE
Add help and arg checking

### DIFF
--- a/bin/esy
+++ b/bin/esy
@@ -163,8 +163,7 @@ execute_any_command() {
 
 if [ $# -eq 0 ]
 then
-  ensureEnvEjected
-  cat "$ENV_PATH"
+  printHelp
 elif [ $# -eq 1 ]; then
   case $1 in
     build|build-shell|clean)
@@ -187,6 +186,10 @@ elif [ $# -eq 1 ]; then
       ;;
     --help|-h)
       printHelp
+      ;;
+    dump-env)
+      ensureEnvEjected
+      cat "$ENV_PATH"
       ;;
     -*)
       echo Unknown option "$1" >&2

--- a/bin/esy
+++ b/bin/esy
@@ -114,29 +114,100 @@ builtInYarn() {
 	node $SCRIPTDIR/yarn.js $@ --cache-folder $ESY__YARN_CACHE_DIR
 }
 
-if [ "$1" == "build" ] || [ "$1" == "build-shell" ] || [ "$1" == "clean" ]; then
-  builtInEject
-  make -j -s -f "$EJECT_PATH/Makefile" "$1"
+printHelp() {
+  cat <<EOF
+  Usage: $0 <command> [--help] [--version]
+  
+  install               Installs package.json packages, but with the ability 
+                        to bridge to other non-npm based package managers.
 
-elif [ "$1" == "build-eject" ]; then
-  builtInEject
+  build                 Builds everything that needs to be built, caches 
+                        results. Builds according to each package's "esy" 
+                        entry in package.json. Before building each package, 
+                        the environment is scrubbed clean then created according
+                        to dependencies.
+  
+  build-shell           Drops into a shell with environment matching your 
+                        package's build environment.
 
-elif [ "$1" == "shell" ]; then
+  shell                 The same as esy build-shell, but creates a "relaxed" 
+                        environment - meaning it also inherits your existing 
+                        shell.
+
+  build-eject           Creates node_modules/.cache/esy/Makefile, which is what
+                        esy build normally runs.
+
+  <command>             Executes <command> as if you had executed it inside of
+                        esy shell.
+                        
+EOF
+}
+
+printVersion() {
+	cat <<EOF
+esy version $ESY__VERSION.
+EOF
+}
+
+execute_any_command() {
   ensureEnvEjected
+
   source "$ENV_PATH"
-  $SHELL
+  # Checks if command ($1) is present available
+  command -v $1 >/dev/null 2>&1 || { 
+  echo >&2 "$1 command is not installed.";
+  exit 1;
+  }
+  exec "$@"
+}
 
-elif [ "$1" == "install" ] || [ "$1" == "add" ]; then
-  builtInYarn $@
-
-else
-
+if [ $# -eq 0 ]
+then
   ensureEnvEjected
-
-  if [ "$1" != "" ]; then
-    source "$ENV_PATH"
-    exec "$@"
-  else
-    cat "$ENV_PATH"
-  fi
+  cat "$ENV_PATH"
+elif [ $# -eq 1 ]; then
+  case $1 in
+    build|build-shell|clean)
+      builtInEject
+      make -j -s -f "$EJECT_PATH/Makefile" "$1"
+      ;;
+    build-eject)
+      builtInEject
+      ;;
+    shell)
+      ensureEnvEjected
+      source "$ENV_PATH"
+      $SHELL
+      ;;
+    install|add)
+      builtInYarn "$@"
+      ;;
+    --version|-v)
+      printVersion
+      ;;
+    --help|-h)
+      printHelp
+      ;;
+    -*)
+      echo Unknown option "$1" >&2
+      exit 1
+      ;;
+    *)
+      execute_any_command "$@"
+      break
+  esac
+else
+  case $1 in
+    add)
+      builtInYarn "$@"
+      ;;
+    -*)
+      echo Unknown option "$1" >&2
+      exit 1
+      ;;
+    *)
+      execute_any_command "$@"
+      break
+  esac
 fi
+


### PR DESCRIPTION
**Summary**

Fixes [#51](https://github.com/jordwalke/esy-issues/issues/51).

Possible improvements:

- [x] Help text. I don't know if the command descriptions (copied from the readme) are satisfying.
- [x] More yarn commands. This script only supports `install` and `add`. Should it support all the yarn commands?
- [x] `--env` option. I find it cool when running plain command like `npm` or `git` shows help although yarn behaves more like esy. I guess it boils down to the question whether `esy --env` would be used frequently or not.

**Test plan**

Run:

- `esy`
- `esy install`
- `esy add left-pad`
- `esy add`
- `esy build`
- `esy build-shell`
- `esy shell`
- `esy build-eject`
- `esy git status` (or any other command)

---

Let me know if I missed anything.
