### PR TITLE
Bump FastReplaceString

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "decompress-zip": "^0.3.0",
     "defaults": "^1.0.3",
     "detect-indent": "^5.0.0",
-    "fastreplacestring": "git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.1",
+    "fastreplacestring": "git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.2",
     "ini": "^1.3.4",
     "inquirer": "^3.0.1",
     "invariant": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1724,9 +1724,9 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-"fastreplacestring@git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.1":
+"fastreplacestring@git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.2":
   version "0.0.1"
-  resolved "git+https://github.com/IwanKaramazow/FastReplaceString.git#a0854c82ce1723993c3f8c5f6a2ad08a74b049d7"
+  resolved "git+https://github.com/IwanKaramazow/FastReplaceString.git#3cf6b8f6d2745eb080b8a6d50765b624b6ac7c65"
 
 fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   version "1.9.2"


### PR DESCRIPTION
Version 0.0.2 contains tests which pass on CI & shouldn't segfault.