### PR TITLE
Make fastreplacestring not segfault again. (finally!)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "decompress-zip": "^0.3.0",
     "defaults": "^1.0.3",
     "detect-indent": "^5.0.0",
-    "fastreplacestring": "git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.3",
+    "fastreplacestring": "git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.4",
     "ini": "^1.3.4",
     "inquirer": "^3.0.1",
     "invariant": "^2.2.0",

--- a/src/esy/buildEjectCommand/index.js
+++ b/src/esy/buildEjectCommand/index.js
@@ -198,7 +198,7 @@ function buildEjectCommand(
       target: '$(ESY__EJECT_ROOT)/bin/fastreplacestring.exe',
       dependencies: ['$(ESY__EJECT_ROOT)/bin/fastreplacestring.cpp'],
       shell: '/bin/bash',
-      command: 'g++ -Ofast -o $(@) -x c++ $(<) 2> /dev/null',
+      command: 'g++ -Ofast -o $(@) $(<) 2> /dev/null',
     },
     {
       type: 'rule',


### PR DESCRIPTION
Segfault free version bump of fastreplacestring, tested & verified on reason-cli with Travis.