### PR TITLE
89: Stop augmenting PATH for irrelevant packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /resources/winsetup/bin
 /resources/win-chocolatey/tools/chocolateyinstall.ps1
 .vs
+.vscode
 *.msi
 *.nupkg
 **/*.pyc

--- a/src/esy/PackageEnvironment.js
+++ b/src/esy/PackageEnvironment.js
@@ -436,16 +436,18 @@ function calculateEnvironment(
       let depManPath = dependencies
         .map(dep => targetPath(sandbox, dep, '_install', 'man'))
         .join(':');
-      sandboxExportedEnvVars = Object.assign(sandboxExportedEnvVars, {
-        'PATH': {
-          val: `${depPath}:$PATH`,
-          exclusive: false,
-        },
-        'MAN_PATH': {
-          val: `${depManPath}:$MAN_PATH`,
-          exclusive: false,
-        }
-      });
+      if (!packageInfo.esy.__noEsyConfigPresent) {
+        sandboxExportedEnvVars = Object.assign(sandboxExportedEnvVars, {
+          'PATH': {
+            val: `${depPath}:$PATH`,
+            exclusive: false,
+          },
+          'MAN_PATH': {
+            val: `${depManPath}:$MAN_PATH`,
+            exclusive: false,
+          }
+        });
+      }
     }
 
     envConfigState = addEnvConfigForPackage(

--- a/src/esy/PackageEnvironment.js
+++ b/src/esy/PackageEnvironment.js
@@ -428,26 +428,25 @@ function calculateEnvironment(
       },
     };
 
-    if (!packageInfo.esy.__noEsyConfigPresent) {
-      let dependencies = collectTransitiveDependencies(packageInfo);
-      if (dependencies.length > 0) {
-        let depPath = dependencies
-          .map(dep => targetPath(sandbox, dep, '_install', 'bin'))
-          .join(':');
-        let depManPath = dependencies
-          .map(dep => targetPath(sandbox, dep, '_install', 'man'))
-          .join(':');
-        sandboxExportedEnvVars = Object.assign(sandboxExportedEnvVars, {
-          'PATH': {
-            val: `${depPath}:$PATH`,
-            exclusive: false,
-          },
-          'MAN_PATH': {
-            val: `${depManPath}:$MAN_PATH`,
-            exclusive: false,
-          }
-        });
-      }
+    let dependencies = collectTransitiveDependencies(packageInfo)
+      .filter(({ esy }) => !esy.__noEsyConfigPresent);
+    if (dependencies.length > 0) {
+      let depPath = dependencies
+        .map(dep => targetPath(sandbox, dep, '_install', 'bin'))
+        .join(':');
+      let depManPath = dependencies
+        .map(dep => targetPath(sandbox, dep, '_install', 'man'))
+        .join(':');
+      sandboxExportedEnvVars = Object.assign(sandboxExportedEnvVars, {
+        'PATH': {
+          val: `${depPath}:$PATH`,
+          exclusive: false,
+        },
+        'MAN_PATH': {
+          val: `${depManPath}:$MAN_PATH`,
+          exclusive: false,
+        }
+      });
     }
 
     envConfigState = addEnvConfigForPackage(

--- a/src/esy/PackageEnvironment.js
+++ b/src/esy/PackageEnvironment.js
@@ -428,15 +428,15 @@ function calculateEnvironment(
       },
     };
 
-    let dependencies = collectTransitiveDependencies(packageInfo);
-    if (dependencies.length > 0) {
-      let depPath = dependencies
-        .map(dep => targetPath(sandbox, dep, '_install', 'bin'))
-        .join(':');
-      let depManPath = dependencies
-        .map(dep => targetPath(sandbox, dep, '_install', 'man'))
-        .join(':');
-      if (!packageInfo.esy.__noEsyConfigPresent) {
+    if (!packageInfo.esy.__noEsyConfigPresent) {
+      let dependencies = collectTransitiveDependencies(packageInfo);
+      if (dependencies.length > 0) {
+        let depPath = dependencies
+          .map(dep => targetPath(sandbox, dep, '_install', 'bin'))
+          .join(':');
+        let depManPath = dependencies
+          .map(dep => targetPath(sandbox, dep, '_install', 'man'))
+          .join(':');
         sandboxExportedEnvVars = Object.assign(sandboxExportedEnvVars, {
           'PATH': {
             val: `${depPath}:$PATH`,


### PR DESCRIPTION
**Summary**

This is for [esy-issues #89](https://github.com/jordwalke/esy-issues/issues/89). The description made it seem very simple, so I wanted to PR early to make sure I wasn't missing some subtlety.

The intent is to avoid polluting `PATH` and `MAN_PATH` with paths to packages that have no esy config. I'm just filtering the collected transitive dependencies for packages that _do_ have one, and that's what ends up in the path.

However! It's my first esy or yarn code of any kind, so: is that all there is?

**Test plan**

*Danger no test plan yet*. Just wanted to make sure I had the right idea.