### PR TITLE
Detect platform during the ejected build runtime

### DIFF
--- a/src/esy/build-sandbox.js
+++ b/src/esy/build-sandbox.js
@@ -181,6 +181,7 @@ async function crawlBuild(
   const maybeDuplicateSpec = context.seenBuildSpecByName.get(packageJson.name);
   if (maybeDuplicateSpec != null) {
     nextErrors.push({
+      // eslint-disable-next-line max-len
       message: `Found multiple instances of "${packageJson.name}" package: ${nextSourcePath} and ${maybeDuplicateSpec.sourcePath}`,
     });
   }
@@ -205,8 +206,6 @@ async function crawlBuild(
 }
 
 function getEnvironment(): BuildEnvironment {
-  const platform = process.env.ESY__TEST ? 'platform' : process.platform;
-  const architecture = process.env.ESY__TEST ? 'architecture' : process.arch;
   return Env.fromEntries([
     {
       name: 'PATH',
@@ -219,39 +218,6 @@ function getEnvironment(): BuildEnvironment {
       name: 'SHELL',
       value: 'env -i /bin/bash --norc --noprofile',
       exclusive: false,
-      builtIn: true,
-      exported: true,
-    },
-
-    // platform and architecture of the host machine
-    {
-      name: 'esy__platform',
-      value: platform,
-      exclusive: true,
-      builtIn: true,
-      exported: true,
-    },
-    {
-      name: 'esy__architecture',
-      value: architecture,
-      exclusive: true,
-      builtIn: true,
-      exported: true,
-    },
-
-    // platform and architecture of the target machine, so that we can do cross
-    // compilation
-    {
-      name: 'esy__target_platform',
-      value: platform,
-      exclusive: true,
-      builtIn: true,
-      exported: true,
-    },
-    {
-      name: 'esy__target_architecture',
-      value: architecture,
-      exclusive: true,
       builtIn: true,
       exported: true,
     },

--- a/src/esy/builders/makefile-builder/runtime.sh
+++ b/src/esy/builders/makefile-builder/runtime.sh
@@ -11,11 +11,14 @@ FG_GREEN='\033[0;32m'
 FG_WHITE='\033[1;37m'
 FG_RESET='\033[0m'
 
+# Configure sandbox mechanism
 ESY__SANDBOX_COMMAND=""
-
-if [[ "$esy__platform" == "darwin" ]]; then
-  ESY__SANDBOX_COMMAND="sandbox-exec -f $cur__target_dir/_esy/sandbox.sb"
-fi
+case $(uname) in
+  Darwin*) ESY__SANDBOX_COMMAND="sandbox-exec -f $cur__target_dir/_esy/sandbox.sb";;
+  Linux*);;
+  MSYS*);;
+  *);;
+esac
 
 _esy-prepare-build-env () {
 


### PR DESCRIPTION
Fixes jordwalke/esy-issues#96

This makes package hashes invariant to the platform/architecture of the
builds. But that's not a problem unless we share packages across
network.