### PR TITLE
Allow configurable build platform

### DIFF
--- a/bin/esy
+++ b/bin/esy
@@ -82,7 +82,7 @@ callBuiltInCommand__buildEject () {
     # Capture the error output
     # Capturing stderr is very important to prevent nodejs from setting
     # stderr to nonblocking mode
-    EJECT_LOG=`node $SCRIPTDIR/../esy/bin/esy.js build-eject "$BUILD_EJECT_PATH" 2>&1`
+    EJECT_LOG=`node $SCRIPTDIR/../esy/bin/esy.js build-eject "$BUILD_EJECT_PATH" $@ 2>&1`
     if [ $? -ne 0 ]; then
       echo "Failed to prepare build environment:"
       printf "%s\n" "$EJECT_LOG" >&2
@@ -140,6 +140,13 @@ printHelp() {
   build-eject           Creates node_modules/.cache/esy/build-eject/Makefile,
                         which is later can be used for building without the NodeJS
                         runtime.
+
+                        Unsupported form: build-eject [cygwin | linux | darwin]
+                        Ejects a build for the specific platform. This
+                        build-eject form is not officially supported and will
+                        be removed soon. It is currently here for debugging
+                        purposes.
+
 
   import-opam           Read a provided opam file and print esy-enabled
                         package.json conents on stdout. Example:
@@ -217,6 +224,9 @@ else
   case $1 in
     import-opam)
       callBuiltInCommand import-opam "$@"
+      ;;
+    build-eject)
+      callBuiltInCommand__buildEject "$@"
       ;;
     add)
       callBuiltInCommand__yarn "$@"

--- a/esy/package.json
+++ b/esy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esy",
-  "version": "0.0.4",
+  "version": "0.0.8",
   "description": "Esy sandboxes for compiled languages",
   "main": "lib/index.js",
   "scripts": {

--- a/esy/src/__tests__/build-task-test.js
+++ b/esy/src/__tests__/build-task-test.js
@@ -66,6 +66,7 @@ const lwt = build({
 const config = Config.createConfig({
   sandboxPath: '<sandboxPath>',
   storePath: '<storePath>',
+  buildPlatform: 'linux',
 });
 
 describe('renderWithScope()', function() {

--- a/esy/src/__tests__/environment-test.js
+++ b/esy/src/__tests__/environment-test.js
@@ -29,6 +29,7 @@ function build({name, exportedEnv, dependencies: dependenciesArray}): BuildSpec 
 const config = createConfig({
   sandboxPath: '<sandboxPath>',
   storePath: '<storePath>',
+  buildPlatform: 'linux',
 });
 
 const ocaml = build({

--- a/esy/src/bin/esy.js
+++ b/esy/src/bin/esy.js
@@ -318,7 +318,6 @@ async function buildEjectCommand(
   const buildPlatform: BuildPlatform = determineBuildPlatformFromArgument(buildPlatformArg);
   const buildEject = require('../builders/makefile-builder');
   const sandbox = await getBuildSandbox(sandboxPath);
-  console.log(process.argv.join('--'));
   const buildConfig = buildConfigForBuildEjectCommand(buildPlatform);
   buildEject.renderToMakefile(
     sandbox,

--- a/esy/src/build-config.js
+++ b/esy/src/build-config.js
@@ -25,8 +25,9 @@ export const STORE_STAGE_TREE = 's';
 export function createConfig(params: {
   storePath: string,
   sandboxPath: string,
+  buildPlatform: BuildPlatform,
 }): BuildConfig {
-  const {storePath, sandboxPath} = params;
+  const {storePath, sandboxPath, buildPlatform} = params;
   const localStorePath = path.join(
     sandboxPath,
     'node_modules',
@@ -46,6 +47,7 @@ export function createConfig(params: {
     sandboxPath,
     storePath,
     localStorePath,
+    buildPlatform,
     getSourcePath: (build: BuildSpec, ...segments) => {
       return path.join(buildConfig.sandboxPath, build.sourcePath, ...segments);
     },

--- a/esy/src/build-task.js
+++ b/esy/src/build-task.js
@@ -37,6 +37,9 @@ function getPathsDelimiter(envVarName: string, buildPlatform: BuildPlatform) {
   if (envVarName === '' || envVarName.charAt(0) === '$') {
     throw new Error('Invalidly formed environment variable:' + envVarName:string);
   }
+  if (buildPlatform === null || buildPlatform === undefined) {
+    throw new Error('Build platform not specified');
+  }
   // Comprehensive pattern matching would be nice to have here!
   return envVarName === 'OCAMLPATH' && buildPlatform === 'cygwin' ? ';' :
       buildPlatform === 'cygwin' ||
@@ -96,7 +99,6 @@ export function fromBuildSpec(
 
   function createTask(scopes): BuildTask {
     const env = new Map();
-
     const ocamlfindDest = config.getInstallPath(scopes.spec, 'lib');
     const ocamlpath = Array.from(scopes.allDependencies.values())
       .map(dep => config.getFinalInstallPath(dep.spec, 'lib'))

--- a/esy/src/builders/makefile-builder/index.js
+++ b/esy/src/builders/makefile-builder/index.js
@@ -22,31 +22,19 @@ const CWD = process.cwd();
 
 const RUNTIME = fs.readFileSync(path.join(__dirname, 'runtime.sh'), 'utf8');
 
-const STORE_PATH = '$ESY_EJECT__STORE';
-const SANDBOX_PATH = '$ESY_EJECT__SANDBOX';
-
 const fastReplaceStringSrc = fs.readFileSync(
   require.resolve('fastreplacestring/fastreplacestring.cpp'),
   'utf8',
 );
 
 /**
- * Note that Makefile based builds defers exact locations of sandbox and store
- * to some later point because ejected builds can be transfered to other
- * machines.
- *
- * That means that build env is generated in a way which can be configured later
- * with `$ESY_EJECT__SANDBOX` and `$ESY__STORE` environment variables.
- */
-export const buildConfig: BuildConfig = Config.createConfig({
-  storePath: STORE_PATH,
-  sandboxPath: SANDBOX_PATH,
-});
-
-/**
  * Render `build` as Makefile (+ related files) into the supplied `outputPath`.
  */
-export function renderToMakefile(sandbox: BuildSandbox, outputPath: string) {
+export function renderToMakefile(
+    sandbox: BuildSandbox,
+    outputPath: string,
+    buildConfig: BuildConfig,
+  ) {
   log(`eject build environment into <ejectRootDir>=./${path.relative(CWD, outputPath)}`);
   const ruleSet: Makefile.MakeItem[] = [
     {

--- a/esy/src/types.js
+++ b/esy/src/types.js
@@ -88,10 +88,20 @@ export type BuildTask = {
   spec: BuildSpec,
 };
 
+export type BuildPlatform = 'darwin' | 'linux' | 'cygwin';
+
 /**
  * Build configuration.
  */
 export type BuildConfig = {
+
+  /**
+   * Which platform the build will actually be performed on. Not necessarily
+   * the same platform that is constructing the build plan.
+   */
+  buildPlatform: BuildPlatform,
+
+
   /**
    * Path to the store used for a build.
    */
@@ -104,6 +114,9 @@ export type BuildConfig = {
 
   /**
    * Path to a sandbox root.
+   * TODO: Model this as sufficiently abstract to prevent treating this as a
+   * string containing a file path. It very well might contain the name of an
+   * environment variable that eventually will contain the actual path.
    */
   sandboxPath: string,
 


### PR DESCRIPTION
Summary:Allows configuration of the build platform, which affects some
details such as path separators. It might affect more than that, but for
now it's just about path separators.

Test Plan:
Successfully built for windows!

Reviewers: @andreypopp 

I haven't used Flow in a long time, so not sure if I did something wrong but everything seems to work.